### PR TITLE
store frame offset in frame struct

### DIFF
--- a/modules/net/quic/frame.c
+++ b/modules/net/quic/frame.c
@@ -2309,8 +2309,10 @@ int quic_frame_stream_append(struct sock *sk, struct quic_frame *frame,
 	/* Update stream data header and frame fields. */
 	p = quic_put_var(frame->data, type);
 	p = quic_put_var(p, stream->id);
-	if (offset)
+	if (offset) {
 		p = quic_put_var(p, offset);
+		frame->offset = offset;
+	}
 	p = quic_put_var(p, frame->bytes + msg_len);
 
 	frame->type = type;


### PR DESCRIPTION
The frame struct provides an offset variable. At least for outgoing frames this field is unused, i.e. the frame offset does not get copied inside the struct. This may affect quic_outq_transmitted_tail() where the offset is used.